### PR TITLE
include token height in calc

### DIFF
--- a/lang/en.json
+++ b/lang/en.json
@@ -4,6 +4,8 @@
         "WallHeightBottomLabel": "Wall Height (Bottom)",
         "AdvancedVisionLabel": "Enable Wall-Height For This Scene",
         "AdvancedMovementLabel": "Enable Wall-Height Movement For This Scene",
-        "ModuleLabel": "Wall Height"
+        "ModuleLabel": "Wall Height",
+        "enableTokenHeight.name": "Enable Token Height",
+        "enableTokenHeight.hint": "Include a token's height (scaled for the scene) when checking if it can see over a wall."
     }
 }

--- a/scripts/patches.js
+++ b/scripts/patches.js
@@ -44,12 +44,14 @@ export function Patch_Token_onUpdate(func,data,options) {
 export function Patch_Walls()
 {
     game.currentTokenElevation = null;
+    game.currentTokenHeight = 0;
     let currentTokenElevation=null; //for backwards compatability
     libWrapper.register(
         MODULE_ID, 'Token.prototype.updateSource',function Patch_UpdateSource(wrapped,...args) {
             // store the token elevation in a common scope, so that it can be used by the following functions without needing to pass it explicitly
             
             game.currentTokenElevation = (typeof _levels !== 'undefined') && _levels?.advancedLOS ? _levels.getTokenLOSheight(this) : this.data.elevation;
+            game.currentTokenHeight = game.settings.get(MODULE_ID,'enableTokenHeight') ? this.data.height * canvas.scene.data.gridDistance : 0
             currentTokenElevation=game.currentTokenElevation;
             wrapped(...args);
     //        currentTokenElevation = null;
@@ -71,7 +73,7 @@ export function Patch_Walls()
         } else{
             if (
                 game.currentTokenElevation == null || !advancedVision ||
-                (game.currentTokenElevation >= wallHeightBottom && game.currentTokenElevation < wallHeightTop)
+                (game.currentTokenElevation >= wallHeightBottom && game.currentTokenElevation + game.currentTokenHeight < wallHeightTop)
             ) {
                 return oldWallsLayerTestWall.apply(this, arguments);
             } else {

--- a/scripts/wall-height.js
+++ b/scripts/wall-height.js
@@ -53,6 +53,14 @@ function registerSettings() {
         type: Boolean,
         default: true
     });
+    game.settings.register(MODULE_ID, 'enableTokenHeight', {
+        name: game.i18n.localize(`${MODULE_SCOPE}.enableTokenHeight.name`),
+        hint: game.i18n.localize(`${MODULE_SCOPE}.enableTokenHeight.hint`),
+        scope: 'world',
+        config: true,
+        type: Boolean,
+        default: false,
+    });
 }
 
 Hooks.on("renderWallConfig", (app, html, data) => {


### PR DESCRIPTION
# Description
This PR adds an module settings option to include a token's `height` attribute (scaled to the scene) to automatically determine if it can see over a wall or not.  The following assumptions are made for this calculation:

1. The tokens used are 3d "cubes" (read: Their width, height, and depth are all equivalent lengths).
2. The character is able to move their head to their foot level or their head level in order to see under or over a wall, respectively.
3. Regardless of in-game height, the character represented by the token has some means of peeking over the top of a wall the same "size" as their token (e.g. hopping to see over a wall).  This also applies for characters with a "size" nominally smaller than their token, e.g. Small characters in D&D that still use a token with a `height` of "1".

Potential room for improvement: 

- Allowing for a config file that maps the token actor's size/in-game height information to an appropriate value, e.g. mapping DnD5e's `"sm"` size enum to 0.5, an elevation-friendly value.
- Creating a Token/PrototypeToken data field for manually setting token height instead

## Issue Number
Partially addresses #11, though perhaps not to the specificity of the original poster.
